### PR TITLE
Port LED example to CubeMX project

### DIFF
--- a/DumbMotor/Core/Inc/gpio.h
+++ b/DumbMotor/Core/Inc/gpio.h
@@ -1,0 +1,22 @@
+#ifndef __GPIO_H
+#define __GPIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "stm32f1xx_hal.h"
+
+#define LED0_Pin GPIO_PIN_5
+#define LED0_GPIO_Port GPIOA
+
+#define LED1_Pin GPIO_PIN_2
+#define LED1_GPIO_Port GPIOD
+
+void MX_GPIO_Init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GPIO_H */

--- a/DumbMotor/Core/Src/gpio.c
+++ b/DumbMotor/Core/Src/gpio.c
@@ -1,0 +1,24 @@
+#include "gpio.h"
+
+void MX_GPIO_Init(void)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+
+    /*Configure GPIO pin Output Level */
+    HAL_GPIO_WritePin(LED0_GPIO_Port, LED0_Pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(LED1_GPIO_Port, LED1_Pin, GPIO_PIN_SET);
+
+    /*Configure GPIO pins : LED0_Pin */
+    GPIO_InitStruct.Pin = LED0_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(LED0_GPIO_Port, &GPIO_InitStruct);
+
+    /*Configure GPIO pin : LED1_Pin */
+    GPIO_InitStruct.Pin = LED1_Pin;
+    HAL_GPIO_Init(LED1_GPIO_Port, &GPIO_InitStruct);
+}

--- a/DumbMotor/Core/Src/main.c
+++ b/DumbMotor/Core/Src/main.c
@@ -21,7 +21,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-
+#include "gpio.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -82,6 +82,7 @@ int main(void)
   /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */
+  MX_GPIO_Init();
   /* USER CODE BEGIN 2 */
 
   /* USER CODE END 2 */
@@ -93,6 +94,12 @@ int main(void)
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
+    HAL_GPIO_WritePin(LED0_GPIO_Port, LED0_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(LED1_GPIO_Port, LED1_Pin, GPIO_PIN_SET);
+    HAL_Delay(300);
+    HAL_GPIO_WritePin(LED0_GPIO_Port, LED0_Pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(LED1_GPIO_Port, LED1_Pin, GPIO_PIN_RESET);
+    HAL_Delay(300);
   }
   /* USER CODE END 3 */
 }


### PR DESCRIPTION
## Summary
- add GPIO initialization for LEDs
- toggle LEDs in `main`
- provide header describing LED pins

## Testing
- `cmake ../DumbMotor` *(fails: CMake 3.31 or higher is required)*

------
https://chatgpt.com/codex/tasks/task_e_687652c44a6483338eea9a17966a4b49