### PR TITLE
Refactor follow-line demo with HAL

### DIFF
--- a/F04_FOLLOWLINE/CMakeLists.txt
+++ b/F04_FOLLOWLINE/CMakeLists.txt
@@ -1,0 +1,73 @@
+#此文件从模板自动生成! 请勿更改!
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+cmake_minimum_required(VERSION 3.31)
+
+# specify cross-compilers and tools
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_ASM_COMPILER  arm-none-eabi-gcc)
+set(CMAKE_AR arm-none-eabi-ar)
+set(CMAKE_OBJCOPY arm-none-eabi-objcopy)
+set(CMAKE_OBJDUMP arm-none-eabi-objdump)
+set(SIZE arm-none-eabi-size)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# project settings
+project(F04_FOLLOWLINE C CXX ASM)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
+
+#Uncomment for hardware floating point
+#add_compile_definitions(ARM_MATH_CM4;ARM_MATH_MATRIX_CHECK;ARM_MATH_ROUNDING)
+#add_compile_options(-mfloat-abi=hard -mfpu=fpv4-sp-d16)
+#add_link_options(-mfloat-abi=hard -mfpu=fpv4-sp-d16)
+
+#Uncomment for software floating point
+#add_compile_options(-mfloat-abi=soft)
+
+add_compile_options(-mcpu=cortex-m3 -mthumb -mthumb-interwork)
+add_compile_options(-ffunction-sections -fdata-sections -fno-common -fmessage-length=0)
+
+# uncomment to mitigate c++17 absolute addresses warnings
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-register")
+
+# Enable assembler files preprocessing
+add_compile_options($<$<COMPILE_LANGUAGE:ASM>:-x$<SEMICOLON>assembler-with-cpp>)
+
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    message(STATUS "Maximum optimization for speed")
+    add_compile_options(-Ofast)
+elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+    message(STATUS "Maximum optimization for speed, debug info included")
+    add_compile_options(-Ofast -g)
+elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
+    message(STATUS "Maximum optimization for size")
+    add_compile_options(-Os)
+else ()
+    message(STATUS "Minimal optimization, debug info included")
+    add_compile_options(-Og -g)
+endif ()
+
+include_directories(Core/Inc Drivers/STM32F1xx_HAL_Driver/Inc Drivers/STM32F1xx_HAL_Driver/Inc/Legacy Drivers/CMSIS/Device/ST/STM32F1xx/Include Drivers/CMSIS/Include)
+
+add_definitions(-DDEBUG -DUSE_HAL_DRIVER -DSTM32F103xE)
+
+file(GLOB_RECURSE SOURCES "Core/*.*" "Drivers/*.*")
+
+set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/STM32F103RCTX_FLASH.ld)
+
+add_link_options(-Wl,-gc-sections,--print-memory-usage,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map)
+add_link_options(-mcpu=cortex-m3 -mthumb -mthumb-interwork)
+add_link_options(-T ${LINKER_SCRIPT})
+
+add_executable(${PROJECT_NAME}.elf ${SOURCES} ${LINKER_SCRIPT})
+
+set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
+set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
+
+add_custom_command(TARGET ${PROJECT_NAME}.elf POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
+        COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
+        COMMENT "Building ${HEX_FILE}
+Building ${BIN_FILE}")

--- a/F04_FOLLOWLINE/Core/Inc/beep.h
+++ b/F04_FOLLOWLINE/Core/Inc/beep.h
@@ -1,0 +1,20 @@
+#ifndef __BEEP_H
+#define __BEEP_H
+
+#include "stm32f1xx_hal.h"
+#include "gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void Beep_Init(void);
+void Beep_On(void);
+void Beep_Off(void);
+void Beep_Toggle(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BEEP_H */

--- a/F04_FOLLOWLINE/Core/Inc/gpio.h
+++ b/F04_FOLLOWLINE/Core/Inc/gpio.h
@@ -1,0 +1,33 @@
+#ifndef __GPIO_H
+#define __GPIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "stm32f1xx_hal.h"
+
+#define LEFT_DIR_Pin  GPIO_PIN_7
+#define LEFT_DIR_GPIO_Port GPIOB
+#define RIGHT_DIR_Pin GPIO_PIN_4
+#define RIGHT_DIR_GPIO_Port GPIOA
+
+#define BEEP_Pin       GPIO_PIN_3
+#define BEEP_GPIO_Port GPIOC
+
+#define KEY_Pin        GPIO_PIN_2
+#define KEY_GPIO_Port  GPIOC
+#define KEY_EXTI_IRQn  EXTI2_IRQn
+
+#define IR_RIGHT_Pin   GPIO_PIN_7
+#define IR_RIGHT_GPIO_Port GPIOA
+#define IR_LEFT_Pin    GPIO_PIN_0
+#define IR_LEFT_GPIO_Port GPIOB
+
+void MX_GPIO_Init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GPIO_H */

--- a/F04_FOLLOWLINE/Core/Inc/motor.h
+++ b/F04_FOLLOWLINE/Core/Inc/motor.h
@@ -1,0 +1,24 @@
+#ifndef __MOTOR_H
+#define __MOTOR_H
+
+#include "stm32f1xx_hal.h"
+#include "tim.h"
+#include "gpio.h"
+
+typedef enum {
+    MOTOR_RIGHT = 0,
+    MOTOR_LEFT
+} Motor_Channel;
+
+void Motor_Init(void);
+void Motor_SetSpeed(Motor_Channel ch, int8_t speed);
+
+void Motor_Run(int8_t speed, uint32_t time_ms);
+void Motor_Brake(uint32_t time_ms);
+void Motor_Left(int8_t speed, uint32_t time_ms);
+void Motor_SpinLeft(int8_t speed, uint32_t time_ms);
+void Motor_Right(int8_t speed, uint32_t time_ms);
+void Motor_SpinRight(int8_t speed, uint32_t time_ms);
+void Motor_Back(int8_t speed, uint32_t time_ms);
+
+#endif

--- a/F04_FOLLOWLINE/Core/Inc/tim.h
+++ b/F04_FOLLOWLINE/Core/Inc/tim.h
@@ -1,0 +1,10 @@
+#ifndef __TIM_H
+#define __TIM_H
+
+#include "stm32f1xx_hal.h"
+
+extern TIM_HandleTypeDef htim4;
+
+void MX_TIM4_Init(void);
+
+#endif

--- a/F04_FOLLOWLINE/Core/Src/beep.c
+++ b/F04_FOLLOWLINE/Core/Src/beep.c
@@ -1,0 +1,21 @@
+#include "beep.h"
+
+void Beep_Init(void)
+{
+    HAL_GPIO_WritePin(BEEP_GPIO_Port, BEEP_Pin, GPIO_PIN_RESET);
+}
+
+void Beep_On(void)
+{
+    HAL_GPIO_WritePin(BEEP_GPIO_Port, BEEP_Pin, GPIO_PIN_SET);
+}
+
+void Beep_Off(void)
+{
+    HAL_GPIO_WritePin(BEEP_GPIO_Port, BEEP_Pin, GPIO_PIN_RESET);
+}
+
+void Beep_Toggle(void)
+{
+    HAL_GPIO_TogglePin(BEEP_GPIO_Port, BEEP_Pin);
+}

--- a/F04_FOLLOWLINE/Core/Src/gpio.c
+++ b/F04_FOLLOWLINE/Core/Src/gpio.c
@@ -1,0 +1,42 @@
+#include "gpio.h"
+
+void MX_GPIO_Init(void)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+
+    HAL_GPIO_WritePin(RIGHT_DIR_GPIO_Port, RIGHT_DIR_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(LEFT_DIR_GPIO_Port, LEFT_DIR_Pin, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(BEEP_GPIO_Port, BEEP_Pin, GPIO_PIN_RESET);
+
+    GPIO_InitStruct.Pin = RIGHT_DIR_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(RIGHT_DIR_GPIO_Port, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = LEFT_DIR_Pin;
+    HAL_GPIO_Init(LEFT_DIR_GPIO_Port, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = BEEP_Pin;
+    HAL_GPIO_Init(BEEP_GPIO_Port, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = KEY_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    HAL_GPIO_Init(KEY_GPIO_Port, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = IR_RIGHT_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    HAL_GPIO_Init(IR_RIGHT_GPIO_Port, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = IR_LEFT_Pin;
+    HAL_GPIO_Init(IR_LEFT_GPIO_Port, &GPIO_InitStruct);
+
+    HAL_NVIC_SetPriority(KEY_EXTI_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(KEY_EXTI_IRQn);
+}

--- a/F04_FOLLOWLINE/Core/Src/main.c
+++ b/F04_FOLLOWLINE/Core/Src/main.c
@@ -18,6 +18,9 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include "motor.h"
+#include "beep.h"
+#include "gpio.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -31,7 +34,6 @@
 
 /* Private define ------------------------------------------------------------*/
 /* USER CODE BEGIN PD */
-
 /* USER CODE END PD */
 
 /* Private macro -------------------------------------------------------------*/
@@ -40,7 +42,6 @@
 /* USER CODE END PM */
 
 /* Private variables ---------------------------------------------------------*/
-TIM_HandleTypeDef htim4;
 
 /* USER CODE BEGIN PV */
 
@@ -48,14 +49,20 @@ TIM_HandleTypeDef htim4;
 
 /* Private function prototypes -----------------------------------------------*/
 void SystemClock_Config(void);
-static void MX_GPIO_Init(void);
-static void MX_TIM4_Init(void);
 /* USER CODE BEGIN PFP */
 
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+  if (GPIO_Pin == KEY_Pin)
+  {
+    Beep_Toggle();
+  }
+}
 
 /* USER CODE END 0 */
 
@@ -65,7 +72,6 @@ static void MX_TIM4_Init(void);
   */
 int main(void)
 {
-
   /* USER CODE BEGIN 1 */
 
   /* USER CODE END 1 */
@@ -87,8 +93,8 @@ int main(void)
   /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */
-  MX_GPIO_Init();
-  MX_TIM4_Init();
+  Motor_Init();
+  Beep_Init();
   /* USER CODE BEGIN 2 */
 
   /* USER CODE END 2 */
@@ -100,6 +106,25 @@ int main(void)
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
+    uint8_t left = HAL_GPIO_ReadPin(IR_LEFT_GPIO_Port, IR_LEFT_Pin);
+    uint8_t right = HAL_GPIO_ReadPin(IR_RIGHT_GPIO_Port, IR_RIGHT_Pin);
+
+    if (left == GPIO_PIN_RESET && right == GPIO_PIN_RESET)
+    {
+      Motor_Run(50, 10);
+    }
+    else if (left == GPIO_PIN_SET && right == GPIO_PIN_RESET)
+    {
+      Motor_Left(50, 10);
+    }
+    else if (right == GPIO_PIN_SET && left == GPIO_PIN_RESET)
+    {
+      Motor_Right(50, 10);
+    }
+    else
+    {
+      Motor_Brake(10);
+    }
   }
   /* USER CODE END 3 */
 }
@@ -141,132 +166,6 @@ void SystemClock_Config(void)
   {
     Error_Handler();
   }
-}
-
-/**
-  * @brief TIM4 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM4_Init(void)
-{
-
-  /* USER CODE BEGIN TIM4_Init 0 */
-
-  /* USER CODE END TIM4_Init 0 */
-
-  TIM_MasterConfigTypeDef sMasterConfig = {0};
-  TIM_OC_InitTypeDef sConfigOC = {0};
-
-  /* USER CODE BEGIN TIM4_Init 1 */
-
-  /* USER CODE END TIM4_Init 1 */
-  htim4.Instance = TIM4;
-  htim4.Init.Prescaler = 0;
-  htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim4.Init.Period = 7199;
-  htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-  htim4.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_PWM_Init(&htim4) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
-  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(&htim4, &sMasterConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = 0;
-  sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
-  sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
-  if (HAL_TIM_PWM_ConfigChannel(&htim4, &sConfigOC, TIM_CHANNEL_3) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  if (HAL_TIM_PWM_ConfigChannel(&htim4, &sConfigOC, TIM_CHANNEL_4) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN TIM4_Init 2 */
-
-  /* USER CODE END TIM4_Init 2 */
-  HAL_TIM_MspPostInit(&htim4);
-
-}
-
-/**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_GPIO_Init(void)
-{
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-/* USER CODE BEGIN MX_GPIO_Init_1 */
-/* USER CODE END MX_GPIO_Init_1 */
-
-  /* GPIO Ports Clock Enable */
-  __HAL_RCC_GPIOD_CLK_ENABLE();
-  __HAL_RCC_GPIOC_CLK_ENABLE();
-  __HAL_RCC_GPIOA_CLK_ENABLE();
-  __HAL_RCC_GPIOB_CLK_ENABLE();
-
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_3, GPIO_PIN_RESET);
-
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_4, GPIO_PIN_RESET);
-
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOB, GPIO_PIN_7, GPIO_PIN_RESET);
-
-  /*Configure GPIO pin : PC2 */
-  GPIO_InitStruct.Pin = GPIO_PIN_2;
-  GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
-  GPIO_InitStruct.Pull = GPIO_PULLUP;
-  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-  /*Configure GPIO pin : PC3 */
-  GPIO_InitStruct.Pin = GPIO_PIN_3;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-  /*Configure GPIO pin : PA4 */
-  GPIO_InitStruct.Pin = GPIO_PIN_4;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-  /*Configure GPIO pin : PA7 */
-  GPIO_InitStruct.Pin = GPIO_PIN_7;
-  GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
-  GPIO_InitStruct.Pull = GPIO_PULLUP;
-  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-  /*Configure GPIO pin : PB0 */
-  GPIO_InitStruct.Pin = GPIO_PIN_0;
-  GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
-  GPIO_InitStruct.Pull = GPIO_PULLUP;
-  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-  /*Configure GPIO pin : PB7 */
-  GPIO_InitStruct.Pin = GPIO_PIN_7;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-  /* EXTI interrupt init*/
-  HAL_NVIC_SetPriority(EXTI2_IRQn, 0, 0);
-  HAL_NVIC_EnableIRQ(EXTI2_IRQn);
-
-/* USER CODE BEGIN MX_GPIO_Init_2 */
-/* USER CODE END MX_GPIO_Init_2 */
 }
 
 /* USER CODE BEGIN 4 */

--- a/F04_FOLLOWLINE/Core/Src/motor.c
+++ b/F04_FOLLOWLINE/Core/Src/motor.c
@@ -1,0 +1,85 @@
+#include "motor.h"
+#include "main.h"
+#include <stdlib.h>
+
+static uint16_t pwm_period = 0;
+
+void Motor_Init(void)
+{
+    MX_TIM4_Init();
+    MX_GPIO_Init();
+    pwm_period = htim4.Init.Period;
+    HAL_TIM_PWM_Start(&htim4, TIM_CHANNEL_3);
+    HAL_TIM_PWM_Start(&htim4, TIM_CHANNEL_4);
+}
+
+void Motor_SetSpeed(Motor_Channel ch, int8_t speed)
+{
+    if (speed > 100) speed = 100;
+    if (speed < -100) speed = -100;
+
+    uint16_t compare = (uint16_t)((pwm_period + 1) * (100 - abs(speed)) / 100);
+
+    if (ch == MOTOR_RIGHT) {
+        __HAL_TIM_SET_COMPARE(&htim4, TIM_CHANNEL_3, compare);
+        if (speed > 0)
+            HAL_GPIO_WritePin(RIGHT_DIR_GPIO_Port, RIGHT_DIR_Pin, GPIO_PIN_RESET);
+        else if (speed < 0)
+            HAL_GPIO_WritePin(RIGHT_DIR_GPIO_Port, RIGHT_DIR_Pin, GPIO_PIN_SET);
+    } else {
+        __HAL_TIM_SET_COMPARE(&htim4, TIM_CHANNEL_4, compare);
+        if (speed > 0)
+            HAL_GPIO_WritePin(LEFT_DIR_GPIO_Port, LEFT_DIR_Pin, GPIO_PIN_SET);
+        else if (speed < 0)
+            HAL_GPIO_WritePin(LEFT_DIR_GPIO_Port, LEFT_DIR_Pin, GPIO_PIN_RESET);
+    }
+}
+
+void Motor_Run(int8_t speed, uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, -speed);
+    Motor_SetSpeed(MOTOR_RIGHT, speed);
+    HAL_Delay(time_ms);
+}
+
+void Motor_Brake(uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, 0);
+    Motor_SetSpeed(MOTOR_RIGHT, 0);
+    HAL_Delay(time_ms);
+}
+
+void Motor_Left(int8_t speed, uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, 0);
+    Motor_SetSpeed(MOTOR_RIGHT, speed);
+    HAL_Delay(time_ms);
+}
+
+void Motor_SpinLeft(int8_t speed, uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, speed);
+    Motor_SetSpeed(MOTOR_RIGHT, speed);
+    HAL_Delay(time_ms);
+}
+
+void Motor_Right(int8_t speed, uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, -speed);
+    Motor_SetSpeed(MOTOR_RIGHT, 0);
+    HAL_Delay(time_ms);
+}
+
+void Motor_SpinRight(int8_t speed, uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, -speed);
+    Motor_SetSpeed(MOTOR_RIGHT, -speed);
+    HAL_Delay(time_ms);
+}
+
+void Motor_Back(int8_t speed, uint32_t time_ms)
+{
+    Motor_SetSpeed(MOTOR_LEFT, speed);
+    Motor_SetSpeed(MOTOR_RIGHT, -speed);
+    HAL_Delay(time_ms);
+}

--- a/F04_FOLLOWLINE/Core/Src/stm32f1xx_hal_msp.c
+++ b/F04_FOLLOWLINE/Core/Src/stm32f1xx_hal_msp.c
@@ -76,7 +76,7 @@ void HAL_MspInit(void)
 
   /** DISABLE: JTAG-DP Disabled and SW-DP Disabled
   */
-  __HAL_AFIO_REMAP_SWJ_DISABLE();
+  /* __HAL_AFIO_REMAP_SWJ_DISABLE(); */
 
   /* USER CODE BEGIN MspInit 1 */
 

--- a/F04_FOLLOWLINE/Core/Src/tim.c
+++ b/F04_FOLLOWLINE/Core/Src/tim.c
@@ -1,0 +1,40 @@
+#include "tim.h"
+#include "main.h"
+
+TIM_HandleTypeDef htim4;
+
+void MX_TIM4_Init(void)
+{
+  TIM_MasterConfigTypeDef sMasterConfig = {0};
+  TIM_OC_InitTypeDef sConfigOC = {0};
+
+  htim4.Instance = TIM4;
+  htim4.Init.Prescaler = 0;
+  htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
+  htim4.Init.Period = 7199;
+  htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim4.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+  if (HAL_TIM_PWM_Init(&htim4) != HAL_OK)
+  {
+    Error_Handler();
+  }
+  sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+  if (HAL_TIMEx_MasterConfigSynchronization(&htim4, &sMasterConfig) != HAL_OK)
+  {
+    Error_Handler();
+  }
+  sConfigOC.OCMode = TIM_OCMODE_PWM1;
+  sConfigOC.Pulse = 0;
+  sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+  sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+  if (HAL_TIM_PWM_ConfigChannel(&htim4, &sConfigOC, TIM_CHANNEL_3) != HAL_OK)
+  {
+    Error_Handler();
+  }
+  if (HAL_TIM_PWM_ConfigChannel(&htim4, &sConfigOC, TIM_CHANNEL_4) != HAL_OK)
+  {
+    Error_Handler();
+  }
+  HAL_TIM_MspPostInit(&htim4);
+}


### PR DESCRIPTION
## Summary
- migrate `04_FOLLOWLINE` example to modern HAL-based project `F04_FOLLOWLINE`
- reuse existing motor control and beep modules
- add GPIO/TIM initialization sources
- implement simple line-following logic
- comment SWJ remap disable line as instructed

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_687747e739748333a54b886f615a0786