### PR TITLE
Add USART distance reporter

### DIFF
--- a/F08_USART/Core/Inc/uart_io.h
+++ b/F08_USART/Core/Inc/uart_io.h
@@ -1,0 +1,16 @@
+#ifndef UART_IO_H
+#define UART_IO_H
+
+#include "stm32f1xx_hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void UART_IO_Init(UART_HandleTypeDef *huart);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UART_IO_H

--- a/F08_USART/Core/Inc/ultrasonic.h
+++ b/F08_USART/Core/Inc/ultrasonic.h
@@ -1,0 +1,20 @@
+#ifndef __ULTRASONIC_H
+#define __ULTRASONIC_H
+
+#include "stm32f1xx_hal.h"
+#include "main.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void Ultrasonic_Init(void);
+void Ultrasonic_Trigger(void);
+float Ultrasonic_Measure(void);
+float Ultrasonic_GetDistance(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ULTRASONIC_H */

--- a/F08_USART/Core/Src/main.c
+++ b/F08_USART/Core/Src/main.c
@@ -18,6 +18,9 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include "ultrasonic.h"
+#include "uart_io.h"
+#include <stdio.h>
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -91,6 +94,8 @@ int main(void)
   MX_GPIO_Init();
   MX_TIM2_Init();
   MX_USART1_UART_Init();
+  UART_IO_Init(&huart1);
+  Ultrasonic_Init();
   /* USER CODE BEGIN 2 */
 
   /* USER CODE END 2 */
@@ -99,6 +104,9 @@ int main(void)
   /* USER CODE BEGIN WHILE */
   while (1)
   {
+    float distance = Ultrasonic_Measure();
+    printf("distance: %.2f cm\r\n", distance);
+    HAL_Delay(1000);
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */

--- a/F08_USART/Core/Src/stm32f1xx_hal_msp.c
+++ b/F08_USART/Core/Src/stm32f1xx_hal_msp.c
@@ -73,7 +73,7 @@ void HAL_MspInit(void)
 
   /** DISABLE: JTAG-DP Disabled and SW-DP Disabled
   */
-  __HAL_AFIO_REMAP_SWJ_DISABLE();
+  /* __HAL_AFIO_REMAP_SWJ_DISABLE(); */
 
   /* USER CODE BEGIN MspInit 1 */
 

--- a/F08_USART/Core/Src/uart_io.c
+++ b/F08_USART/Core/Src/uart_io.c
@@ -1,0 +1,19 @@
+#include "uart_io.h"
+#include <string.h>
+
+static UART_HandleTypeDef *debug_huart = NULL;
+
+void UART_IO_Init(UART_HandleTypeDef *huart)
+{
+    debug_huart = huart;
+}
+
+int __io_putchar(int ch)
+{
+    uint8_t c = (uint8_t)ch;
+    if (debug_huart)
+    {
+        HAL_UART_Transmit(debug_huart, &c, 1, HAL_MAX_DELAY);
+    }
+    return ch;
+}

--- a/F08_USART/Core/Src/ultrasonic.c
+++ b/F08_USART/Core/Src/ultrasonic.c
@@ -1,0 +1,53 @@
+#include "ultrasonic.h"
+
+extern TIM_HandleTypeDef htim2;
+
+static volatile float last_distance = 0.0f;
+
+static void delay_us(uint32_t us)
+{
+    uint32_t start = DWT->CYCCNT;
+    uint32_t cycles = (HAL_RCC_GetHCLKFreq() / 1000000) * us;
+    while ((DWT->CYCCNT - start) < cycles) {
+    }
+}
+
+void Ultrasonic_Init(void)
+{
+    /* enable DWT cycle counter for microsecond delay */
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+}
+
+void Ultrasonic_Trigger(void)
+{
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_0, GPIO_PIN_SET);
+    delay_us(20);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_0, GPIO_PIN_RESET);
+}
+
+float Ultrasonic_GetDistance(void)
+{
+    return last_distance;
+}
+
+float Ultrasonic_Measure(void)
+{
+    Ultrasonic_Trigger();
+    HAL_Delay(60);
+    return last_distance;
+}
+
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+    if (GPIO_Pin == GPIO_PIN_1)
+    {
+        __HAL_TIM_SET_COUNTER(&htim2, 0);
+        HAL_TIM_Base_Start(&htim2);
+        while (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_1) == GPIO_PIN_SET) {
+        }
+        HAL_TIM_Base_Stop(&htim2);
+        uint32_t ticks = __HAL_TIM_GET_COUNTER(&htim2);
+        last_distance = ticks * 100.0f / 58.0f; /* timer tick = 100us */
+    }
+}

--- a/F08_USART/config_ioc_steps.md
+++ b/F08_USART/config_ioc_steps.md
@@ -1,0 +1,26 @@
+# STM32CubeMX 配置步骤
+
+以下步骤演示如何在 STM32CubeMX 中生成 `F08_USART` 工程的 `.ioc` 文件，用于 STM32F103RCT6 开发板：
+
+1. **新建工程**
+   - 打开 STM32CubeMX，点击 **New Project**。
+   - 在 MCU/MPU Selector 中选择 `STM32F103RCT6`（LQFP64）。
+
+2. **配置时钟**
+   - 在 **Clock Configuration** 页面启用外部高速晶振 (HSE, 8MHz)。
+   - 启用 PLL，倍频系数设置为 9，使系统时钟达到 72MHz。
+
+3. **配置 GPIO 与定时器**
+   - `PC0` 设为 **GPIO_Output**，用作超声波 TRIG。
+   - `PC1` 设为 **GPIO_Input** 并启用 **EXTI Line1**，用作超声波 ECHO。
+   - 启用 **TIM2**，`Prescaler` 设为 `7199`，`Counter Period` 设为 `4999`，用于测量回波时间。
+   - 在 **NVIC Settings** 中启用 `TIM2` 与 `EXTI1` 中断。
+
+4. **配置串口**
+   - 启用 **USART1**，引脚 `PA9` 作为 TX、`PA10` 作为 RX，波特率设置为 115200。
+
+5. **生成代码**
+   - 在 **Project Manager** 中设置工程名称 `F08_USART`，生成方式可以选择 Makefile。
+   - 点击 **Generate Code**，将生成的 `Core` 和 `Drivers` 目录替换到本工程相应位置。
+
+完成以上步骤后即可在 CLion 中编译和调试该项目。


### PR DESCRIPTION
## Summary
- implement serial distance reporting example in `F08_USART`
- include UART IO helper for printf output
- add ultrasonic driver
- disable SWJ remap as per root instructions
- document CubeMX setup steps for USART example

## Testing
- `cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_6877b06c8c9c8333bfefa857e29d00ca