### PR TITLE
Update servo sweep and corner handling

### DIFF
--- a/Dumb-Motor/Core/Src/avoid.c
+++ b/Dumb-Motor/Core/Src/avoid.c
@@ -16,7 +16,8 @@ void servo_sweep(void)
     sweep_idx++;
     if(sweep_idx>10) sweep_idx=-10;
     us_idx = sweep_idx + 10;
-    float angle = 90.0f + sweep_idx*9.0f;
+    /* Servo scans from 50° to 180° with 115° as center */
+    float angle = 115.0f + sweep_idx*6.5f;
     Servo_SetAngle(angle);
     Ultrasonic_Trigger();
 }

--- a/Dumb-Motor/Core/Src/follow.c
+++ b/Dumb-Motor/Core/Src/follow.c
@@ -14,10 +14,15 @@ void follow_update(void)
 
     if(qi!=qj) return;
 
-    if(!g_L && !g_R) err = 0;
-    else if(g_L && !g_R) err = +1;
-    else if(!g_L && g_R) err = -1;
-    else err = (err>0)?+2:-2;
+    if(!g_L && !g_R) {
+        err = 0;
+    } else if(g_L && !g_R) {
+        err = +1;
+    } else if(!g_L && g_R) {
+        err = -1;
+    } else { /* g_L && g_R */
+        err = (err>0)?+2:-2;
+    }
 
     if(err==0) step_cnt=0;
     else if(step_cnt<STEP_LIMIT) step_cnt++;
@@ -26,10 +31,13 @@ void follow_update(void)
         case 0: enqueue(FWD, FWD_MS); break;
         case +1: enqueue(R10, TURN_MS); enqueue(FWD, FWD_MS/2); break;
         case -1: enqueue(L10, TURN_MS); enqueue(FWD, FWD_MS/2); break;
-        default:
+        default: {
             enqueue(BRK, BRAKE_MS);
             enqueue(BWD, BWD_MS);
-            enqueue((err>0)?R10:L10, TURN_MS*2);
+            uint8_t turns = (g_L && g_R) ? 9 : 2; /* bigger turn when both sensors see black */
+            for(uint8_t k=0;k<turns;k++)
+                enqueue((err>0)?R10:L10, TURN_MS);
             break;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- adjust servo scan range to 50°–180° with 115° center
- add strong turn when both IR sensors read black
- run cmake build to check project

## Testing
- `./install_cmake3.31.sh`
- `cmake ..`
- `cmake --build .` *(fails: `tim.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687856814f3483338b80d47d37053463