### PR TITLE
Implement LCD text output

### DIFF
--- a/F09_LCD/CMakeLists.txt
+++ b/F09_LCD/CMakeLists.txt
@@ -1,0 +1,73 @@
+#此文件从模板自动生成! 请勿更改!
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+cmake_minimum_required(VERSION 3.31)
+
+# specify cross-compilers and tools
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_ASM_COMPILER  arm-none-eabi-gcc)
+set(CMAKE_AR arm-none-eabi-ar)
+set(CMAKE_OBJCOPY arm-none-eabi-objcopy)
+set(CMAKE_OBJDUMP arm-none-eabi-objdump)
+set(SIZE arm-none-eabi-size)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# project settings
+project(F09_LCD C CXX ASM)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
+
+#Uncomment for hardware floating point
+#add_compile_definitions(ARM_MATH_CM4;ARM_MATH_MATRIX_CHECK;ARM_MATH_ROUNDING)
+#add_compile_options(-mfloat-abi=hard -mfpu=fpv4-sp-d16)
+#add_link_options(-mfloat-abi=hard -mfpu=fpv4-sp-d16)
+
+#Uncomment for software floating point
+#add_compile_options(-mfloat-abi=soft)
+
+add_compile_options(-mcpu=cortex-m3 -mthumb -mthumb-interwork)
+add_compile_options(-ffunction-sections -fdata-sections -fno-common -fmessage-length=0)
+
+# uncomment to mitigate c++17 absolute addresses warnings
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-register")
+
+# Enable assembler files preprocessing
+add_compile_options($<$<COMPILE_LANGUAGE:ASM>:-x$<SEMICOLON>assembler-with-cpp>)
+
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    message(STATUS "Maximum optimization for speed")
+    add_compile_options(-Ofast)
+elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+    message(STATUS "Maximum optimization for speed, debug info included")
+    add_compile_options(-Ofast -g)
+elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
+    message(STATUS "Maximum optimization for size")
+    add_compile_options(-Os)
+else ()
+    message(STATUS "Minimal optimization, debug info included")
+    add_compile_options(-Og -g)
+endif ()
+
+include_directories(Core/Inc Drivers/STM32F1xx_HAL_Driver/Inc Drivers/STM32F1xx_HAL_Driver/Inc/Legacy Drivers/CMSIS/Device/ST/STM32F1xx/Include Drivers/CMSIS/Include)
+
+add_definitions(-DDEBUG -DUSE_HAL_DRIVER -DSTM32F103xE)
+
+file(GLOB_RECURSE SOURCES "Core/*.*" "Drivers/*.*")
+
+set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/STM32F103RCTX_FLASH.ld)
+
+add_link_options(-Wl,-gc-sections,--print-memory-usage,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map)
+add_link_options(-mcpu=cortex-m3 -mthumb -mthumb-interwork)
+add_link_options(-T ${LINKER_SCRIPT})
+
+add_executable(${PROJECT_NAME}.elf ${SOURCES} ${LINKER_SCRIPT})
+
+set(HEX_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.hex)
+set(BIN_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin)
+
+add_custom_command(TARGET ${PROJECT_NAME}.elf POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${PROJECT_NAME}.elf> ${HEX_FILE}
+        COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}.elf> ${BIN_FILE}
+        COMMENT "Building ${HEX_FILE}
+Building ${BIN_FILE}")

--- a/F09_LCD/Core/Inc/gpio.h
+++ b/F09_LCD/Core/Inc/gpio.h
@@ -1,0 +1,29 @@
+#ifndef __GPIO_H
+#define __GPIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "stm32f1xx_hal.h"
+
+#define LCD_CS_Pin       GPIO_PIN_5
+#define LCD_CS_GPIO_Port GPIOA
+
+#define LCD_CLK_Pin      GPIO_PIN_4
+#define LCD_CLK_GPIO_Port GPIOA
+
+#define LCD_DIO_Pin      GPIO_PIN_6
+#define LCD_DIO_GPIO_Port GPIOA
+
+#define LCD_RST_Pin      GPIO_PIN_3
+#define LCD_RST_GPIO_Port GPIOA
+
+#define LCD_PSB_Pin      GPIO_PIN_9
+#define LCD_PSB_GPIO_Port GPIOB
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GPIO_H */

--- a/F09_LCD/Core/Inc/lcd.h
+++ b/F09_LCD/Core/Inc/lcd.h
@@ -1,0 +1,19 @@
+#ifndef LCD_H
+#define LCD_H
+
+#include "stm32f1xx_hal.h"
+#include "gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void LCD_Init(void);
+void LCD_Clear(void);
+void LCD_Print(const char *str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LCD_H

--- a/F09_LCD/Core/Src/lcd.c
+++ b/F09_LCD/Core/Src/lcd.c
@@ -1,0 +1,101 @@
+#include "lcd.h"
+
+static uint8_t current_row = 0;
+static uint8_t current_col = 0;
+
+static const uint8_t row_addr[4] = {0x80, 0x90, 0x88, 0x98};
+
+static void lcd_send_byte(uint8_t data)
+{
+    for (uint8_t i = 0; i < 8; ++i)
+    {
+        HAL_GPIO_WritePin(LCD_DIO_GPIO_Port, LCD_DIO_Pin,
+                          (data & 0x80) ? GPIO_PIN_SET : GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(LCD_CLK_GPIO_Port, LCD_CLK_Pin, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(LCD_CLK_GPIO_Port, LCD_CLK_Pin, GPIO_PIN_SET);
+        data <<= 1;
+    }
+}
+
+static void lcd_write_command(uint8_t cmd)
+{
+    HAL_GPIO_WritePin(LCD_CS_GPIO_Port, LCD_CS_Pin, GPIO_PIN_RESET);
+    lcd_send_byte(0xF8);
+    lcd_send_byte(cmd & 0xF0);
+    lcd_send_byte((cmd << 4) & 0xF0);
+    HAL_GPIO_WritePin(LCD_CS_GPIO_Port, LCD_CS_Pin, GPIO_PIN_SET);
+    HAL_Delay(2);
+}
+
+static void lcd_write_data(uint8_t data)
+{
+    HAL_GPIO_WritePin(LCD_CS_GPIO_Port, LCD_CS_Pin, GPIO_PIN_RESET);
+    lcd_send_byte(0xFA);
+    lcd_send_byte(data & 0xF0);
+    lcd_send_byte((data << 4) & 0xF0);
+    HAL_GPIO_WritePin(LCD_CS_GPIO_Port, LCD_CS_Pin, GPIO_PIN_SET);
+    HAL_Delay(2);
+}
+
+static void lcd_set_address(uint8_t row, uint8_t col)
+{
+    lcd_write_command(0x30);
+    lcd_write_command(row_addr[row] + col);
+}
+
+void LCD_Init(void)
+{
+    HAL_GPIO_WritePin(LCD_RST_GPIO_Port, LCD_RST_Pin, GPIO_PIN_RESET);
+    HAL_Delay(90);
+    HAL_GPIO_WritePin(LCD_RST_GPIO_Port, LCD_RST_Pin, GPIO_PIN_SET);
+    HAL_Delay(90);
+
+    lcd_write_command(0x30);
+    HAL_Delay(2);
+    lcd_write_command(0x06);
+    HAL_Delay(2);
+    lcd_write_command(0x01);
+    HAL_Delay(2);
+    lcd_write_command(0x0C);
+    HAL_Delay(2);
+    lcd_write_command(0x02);
+    HAL_Delay(2);
+}
+
+void LCD_Clear(void)
+{
+    lcd_write_command(0x01);
+    HAL_Delay(2);
+    current_row = 0;
+    current_col = 0;
+}
+
+static void lcd_put_char(char ch)
+{
+    if (current_col >= 16)
+    {
+        current_col = 0;
+        current_row = (current_row + 1) % 4;
+    }
+    lcd_set_address(current_row, current_col);
+    lcd_write_data((uint8_t)ch);
+    current_col++;
+}
+
+void LCD_Print(const char *str)
+{
+    while (*str)
+    {
+        if (*str == '\n')
+        {
+            current_row = (current_row + 1) % 4;
+            current_col = 0;
+            lcd_set_address(current_row, current_col);
+        }
+        else
+        {
+            lcd_put_char(*str);
+        }
+        str++;
+    }
+}

--- a/F09_LCD/Core/Src/main.c
+++ b/F09_LCD/Core/Src/main.c
@@ -21,6 +21,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "lcd.h"
 
 /* USER CODE END Includes */
 
@@ -90,13 +91,16 @@ int main(void)
   MX_GPIO_Init();
   MX_USART1_UART_Init();
   /* USER CODE BEGIN 2 */
-
+  LCD_Init();
+  LCD_Clear();
+  LCD_Print("Hello LCD!\nZJU Dumb Motor");
   /* USER CODE END 2 */
 
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
   while (1)
   {
+    /* 主循环保持空闲，LCD 上的内容保持不变 */
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */

--- a/F09_LCD/Core/Src/stm32f1xx_hal_msp.c
+++ b/F09_LCD/Core/Src/stm32f1xx_hal_msp.c
@@ -74,7 +74,11 @@ void HAL_MspInit(void)
 
   /** DISABLE: JTAG-DP Disabled and SW-DP Disabled
   */
-  __HAL_AFIO_REMAP_SWJ_DISABLE();
+  /*
+   * 在使用 ST-Link 下载程序时，如不屏蔽该行将导致调试口被复用，
+   * 从而无法再次烧录程序。故此处保持默认的 JTAG/SWD 接口映射。
+   */
+  /* __HAL_AFIO_REMAP_SWJ_DISABLE(); */
 
   /* USER CODE BEGIN MspInit 1 */
 

--- a/F09_LCD/config_ioc_steps.md
+++ b/F09_LCD/config_ioc_steps.md
@@ -1,0 +1,22 @@
+# STM32CubeMX 配置步骤
+
+以下步骤演示如何在 STM32CubeMX 中生成 `F09_LCD` 工程的 `.ioc` 文件：
+
+1. **新建工程**
+   - 打开 STM32CubeMX，选择 `STM32F103RCT6`（LQFP64 封装）。
+2. **配置时钟**
+   - 在 **Clock Configuration** 页启用外部高速晶振 (HSE, 8MHz)。
+   - 使能 PLL，倍频系数设为 9，使系统时钟达到 72MHz。
+3. **配置 GPIO**
+   - 将以下引脚设为 `GPIO_Output` 并在 `User Label` 中注明用途：
+     - `PA3` : `LCD_RST`
+     - `PA4` : `LCD_CLK`
+     - `PA5` : `LCD_CS`
+     - `PA6` : `LCD_DIO`
+     - `PB9` : `LCD_PSB`
+   - 若需要按键功能，可将 `PA0`~`PA2` 和 `PB0`~`PB7` 设为 `GPIO_Input`，并启用上拉。
+4. **配置串口**
+   - 启用 `USART1`，`PA9` 为 TX，`PA10` 为 RX，波特率 115200。
+5. **生成代码**
+   - 在 **Project Manager** 中设置工程名称 `F09_LCD`，选择生成 `Makefile` 工程。
+   - 点击 **Generate Code**，生成的 `Core` 与 `Drivers` 覆盖到本仓库对应位置即可。


### PR DESCRIPTION
## Summary
- add HAL-based LCD driver for F09_LCD
- show LCD usage in main
- set up cross-compilation CMakeLists
- document CubeMX configuration steps for the LCD project
- keep SWJ remap disabled to allow flashing

## Testing
- `cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_6878663425948333819512a043734a34