### PR TITLE
Fix dumb-motor obstacle logic

### DIFF
--- a/Dumb-Motor/Core/Inc/follow.h
+++ b/Dumb-Motor/Core/Inc/follow.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 void follow_update(void);
+void follow_read_sensors(void);
 
 #ifdef __cplusplus
 }

--- a/Dumb-Motor/Core/Src/follow.c
+++ b/Dumb-Motor/Core/Src/follow.c
@@ -7,10 +7,15 @@
 static int8_t err = 0;
 static uint8_t step_cnt = 0;
 
-void follow_update(void)
+void follow_read_sensors(void)
 {
     g_L = (HAL_GPIO_ReadPin(IR_LEFT_GPIO_Port, IR_LEFT_Pin) == GPIO_PIN_RESET);
     g_R = (HAL_GPIO_ReadPin(IR_RIGHT_GPIO_Port, IR_RIGHT_Pin) == GPIO_PIN_RESET);
+}
+
+void follow_update(void)
+{
+    follow_read_sensors();
 
     if(qi!=qj) return;
 

--- a/Dumb-Motor/Core/Src/fsm.c
+++ b/Dumb-Motor/Core/Src/fsm.c
@@ -11,6 +11,7 @@ static uint16_t recover_ms = 0;
 
 void fsm_tick(void)
 {
+    follow_read_sensors();
     switch(g_state){
         case FOLLOW:
             Beep_Off();

--- a/Dumb-Motor/Core/Src/ultrasonic.c
+++ b/Dumb-Motor/Core/Src/ultrasonic.c
@@ -19,6 +19,9 @@ void Ultrasonic_Init(void)
     /* enable DWT cycle counter for microsecond delay */
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    for(int i=0;i<21;i++)
+        us_dist[i] = 1000;
 }
 
 void Ultrasonic_Trigger(void)


### PR DESCRIPTION
## Summary
- ensure IR sensor values are refreshed in all FSM states
- init ultrasonic distance buffer to safe values

## Testing
- `./install_cmake3.31.sh`
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6878675233a08333a14e51ea6bbecdfb