### PR TITLE
Add IR sensor handling and FSM

### DIFF
--- a/Test-Motor/Core/Inc/follow.h
+++ b/Test-Motor/Core/Inc/follow.h
@@ -1,0 +1,9 @@
+#ifndef __FOLLOW_H
+#define __FOLLOW_H
+
+#include "stm32f1xx_hal.h"
+
+void ir_update(void);
+void follow_update(void);
+
+#endif

--- a/Test-Motor/Core/Inc/fsm.h
+++ b/Test-Motor/Core/Inc/fsm.h
@@ -1,0 +1,8 @@
+#ifndef __FSM_H
+#define __FSM_H
+
+#include "config.h"
+
+void fsm_tick(void);
+
+#endif

--- a/Test-Motor/Core/Inc/gpio.h
+++ b/Test-Motor/Core/Inc/gpio.h
@@ -12,6 +12,11 @@ extern "C" {
 #define RIGHT_DIR_Pin GPIO_PIN_4
 #define RIGHT_DIR_GPIO_Port GPIOA
 
+#define IR_RIGHT_Pin  GPIO_PIN_7
+#define IR_RIGHT_GPIO_Port GPIOA
+#define IR_LEFT_Pin   GPIO_PIN_0
+#define IR_LEFT_GPIO_Port GPIOB
+
 //void MX_GPIO_Init(void);
 
 #ifdef __cplusplus

--- a/Test-Motor/Core/Inc/queue.h
+++ b/Test-Motor/Core/Inc/queue.h
@@ -17,7 +17,10 @@ extern volatile uint8_t qi, qj;
 
 void enqueue(Act a, uint16_t t);
 void queue_tick(void);
-int is_empty(void);
+int queue_is_empty(void);
+int queue_is_full(void);
+void queue_clear(void);
+#define is_empty queue_is_empty
 #ifdef __cplusplus
 }
 #endif

--- a/Test-Motor/Core/Src/follow.c
+++ b/Test-Motor/Core/Src/follow.c
@@ -1,0 +1,51 @@
+#include "follow.h"
+#include "gpio.h"
+#include "queue.h"
+#include "config.h"
+
+volatile uint8_t g_L = 0, g_R = 0;
+
+void ir_update(void)
+{
+    g_L = (HAL_GPIO_ReadPin(IR_LEFT_GPIO_Port, IR_LEFT_Pin) == GPIO_PIN_SET);
+    g_R = (HAL_GPIO_ReadPin(IR_RIGHT_GPIO_Port, IR_RIGHT_Pin) == GPIO_PIN_SET);
+}
+
+void follow_update(void)
+{
+    static int8_t err = 0;
+    static uint8_t step_cnt = 0;
+
+    if(!queue_is_empty())
+        return;
+
+    if(!g_L && !g_R)      err = 0;
+    else if(g_L && !g_R)  err = +1;
+    else if(!g_L && g_R)  err = -1;
+    else                  err = (err>0)? +2 : -2;
+
+    if(err==0) step_cnt = 0;
+    else if(step_cnt < STEP_LIMIT) step_cnt++;
+
+    if(err != 0)
+        queue_clear();
+
+    switch(err){
+        case 0:
+            enqueue(FWD, FWD_MS);
+            break;
+        case +1:
+            enqueue(R10, TURN_MS);
+            enqueue(FWD, FWD_MS/2);
+            break;
+        case -1:
+            enqueue(L10, TURN_MS);
+            enqueue(FWD, FWD_MS/2);
+            break;
+        default:
+            enqueue(BRK, BRAKE_MS);
+            enqueue(BWD, BWD_MS);
+            enqueue((err>0)? R10 : L10, TURN_MS*2);
+            break;
+    }
+}

--- a/Test-Motor/Core/Src/fsm.c
+++ b/Test-Motor/Core/Src/fsm.c
@@ -1,0 +1,29 @@
+#include "fsm.h"
+#include "follow.h"
+#include "queue.h"
+
+volatile State g_state = FOLLOW;
+
+void fsm_tick(void)
+{
+    static uint8_t cnt = 0;
+
+    ir_update();
+
+    switch(g_state)
+    {
+        case FOLLOW:
+            if(++cnt >= 10)
+            {
+                cnt = 0;
+                follow_update();
+            }
+            break;
+        case AVOID:
+            if(queue_is_empty())
+                g_state = FOLLOW;
+            break;
+        case RECOVER:
+            break;
+    }
+}

--- a/Test-Motor/Core/Src/queue.c
+++ b/Test-Motor/Core/Src/queue.c
@@ -8,12 +8,25 @@ static uint16_t rest = 0;
 
 void enqueue(Act a, uint16_t t)
 {
+    if(queue_is_full()) return;
     q[qj] = (Cmd){a,t};
     qj = (qj + 1) & (QLEN - 1);
 }
-int is_empty(void)
+
+int queue_is_empty(void)
 {
     return (qi == qj);
+}
+
+int queue_is_full(void)
+{
+    return (((qj + 1) & (QLEN - 1)) == qi);
+}
+
+void queue_clear(void)
+{
+    qi = qj = 0;
+    rest = 0;
 }
 
 void queue_tick(void)

--- a/Test-Motor/Core/Src/stm32f1xx_it.c
+++ b/Test-Motor/Core/Src/stm32f1xx_it.c
@@ -23,6 +23,7 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include "queue.h"
+#include "fsm.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -185,6 +186,7 @@ void SysTick_Handler(void)
 {
   /* USER CODE BEGIN SysTick_IRQn 0 */
   queue_tick();
+  fsm_tick();
 
   /* USER CODE END SysTick_IRQn 0 */
   HAL_IncTick();


### PR DESCRIPTION
## Summary
- add IR pin macros
- extend queue API to query/full clear
- implement queue helpers
- add follow logic for down-facing IR sensors
- implement simple FSM and run in SysTick

## Testing
- `cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_68788f954c848333b80cb0de6cd1c856