### PR TITLE
Improve obstacle avoidance logic

### DIFF
--- a/Test-Motor/Core/Inc/config.h
+++ b/Test-Motor/Core/Inc/config.h
@@ -9,6 +9,7 @@
 #define BWD_MS         60
 #define BRAKE_MS       40
 #define D_SAFE         200
+#define AVOID_TIMEOUT  3000
 
 #include <stdbool.h>
 

--- a/Test-Motor/Core/Src/fsm.c
+++ b/Test-Motor/Core/Src/fsm.c
@@ -4,6 +4,7 @@
 #include "avoid.h"
 
 volatile State g_state = FOLLOW;
+static uint32_t avoid_ticks = 0;
 
 void fsm_tick(void)
 {
@@ -18,6 +19,7 @@ void fsm_tick(void)
             {
                 avoid_plan();
                 g_state = AVOID;
+                avoid_ticks = 0;
             }
             else if(++cnt >= 10)
             {
@@ -26,8 +28,19 @@ void fsm_tick(void)
             }
             break;
         case AVOID:
+            avoid_ticks++;
+            if(avoid_ticks > AVOID_TIMEOUT)
+            {
+                queue_clear();
+                enqueue(BWD, 4*BWD_MS);
+                enqueue(L10, 3*TURN_MS);
+                avoid_ticks = 0;
+            }
             if(queue_is_empty())
+            {
                 g_state = FOLLOW;
+                avoid_ticks = 0;
+            }
             break;
         case RECOVER:
             break;

--- a/Test-Motor/Core/Src/servo.c
+++ b/Test-Motor/Core/Src/servo.c
@@ -35,10 +35,6 @@ void Servo_SetAngle(float angle)
     uint32_t compare = (uint32_t)(scaled * 1000.0f + 249.0f);
     __HAL_TIM_SET_COMPARE(&htim5, TIM_CHANNEL_1, compare);
 
-    if(angle > SERVO_CENTER_ANGLE)
-        Beep_On();
-    else
-        Beep_Off();
 }
 
 static int8_t sweep_idx = -10;

--- a/Test-Motor/Core/Src/ultrasonic.c
+++ b/Test-Motor/Core/Src/ultrasonic.c
@@ -2,6 +2,7 @@
 #include "gpio.h"
 #include "tim.h"
 #include "config.h"
+#include "beep.h"
 
 extern TIM_HandleTypeDef htim2;
 
@@ -55,6 +56,10 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
             uint32_t ticks = __HAL_TIM_GET_COUNTER(&htim2);
             last_distance = ticks * 100.0f / 58.0f; /* 100us tick */
             us_dist[us_idx] = (uint16_t)last_distance;
+            if(last_distance < D_SAFE)
+                Beep_On();
+            else
+                Beep_Off();
             start = 0;
         }
     }


### PR DESCRIPTION
## Summary
- add `AVOID_TIMEOUT` constant
- beep when ultrasonic distance is below safe threshold
- remove servo-angle based beeping
- add timeout recovery in AVOID state

## Testing
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68789dfbd9648333833f4e7971196201