### PR TITLE
Add on-demand ultrasonic scanning

### DIFF
--- a/Test-Motor/Core/Inc/config.h
+++ b/Test-Motor/Core/Inc/config.h
@@ -16,8 +16,11 @@
 typedef enum {FOLLOW, AVOID, RECOVER} State;
 
 extern volatile uint8_t g_L, g_R;
-extern volatile uint16_t us_dist[21];
-extern volatile uint8_t us_idx;
+extern volatile uint16_t dist_center;
+extern volatile uint16_t dist_left;
+extern volatile uint16_t dist_right;
+
+typedef enum {US_POS_CENTER, US_POS_LEFT, US_POS_RIGHT} UltrasonicPos;
 extern volatile State g_state;
 
 #endif /* __CONFIG_H */

--- a/Test-Motor/Core/Inc/ultrasonic.h
+++ b/Test-Motor/Core/Inc/ultrasonic.h
@@ -2,6 +2,7 @@
 #define __ULTRASONIC_H
 
 #include "stm32f1xx_hal.h"
+#include "config.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -10,7 +11,7 @@ extern "C" {
 void Ultrasonic_Init(void);
 void Ultrasonic_Trigger(void);
 float Ultrasonic_GetDistance(void);
-void Ultrasonic_StartMeasurement(void);
+void Ultrasonic_StartMeasurement(UltrasonicPos pos);
 
 #ifdef __cplusplus
 }

--- a/Test-Motor/Core/Src/avoid.c
+++ b/Test-Motor/Core/Src/avoid.c
@@ -1,48 +1,18 @@
 #include "avoid.h"
 #include "queue.h"
+#include "ultrasonic.h"
 
 int front_blocked(void)
 {
-    return us_dist[10] < D_SAFE;
+    return dist_center < D_SAFE;
 }
 
 void avoid_plan(void)
 {
-    uint8_t free[21];
-    for(int i=0;i<21;i++)
-        free[i] = (us_dist[i] > D_SAFE) ? 1 : 0;
-
-    if(g_L)
-        for(int i=0;i<5;i++)
-            free[i] = 0;
-    if(g_R)
-        for(int i=16;i<21;i++)
-            free[i] = 0;
-
-    int best_len = 0, best_start = 10;
-    int len = 0, start = 0;
-    for(int i=0;i<=21;i++)
-    {
-        if(i<21 && free[i])
-        {
-            if(len==0) start = i;
-            len++;
-        }
-        else
-        {
-            if(len>best_len){ best_len = len; best_start = start; }
-            len = 0;
-        }
-    }
-    int center = best_start + best_len/2;
-    int n = center - 10;
-
     queue_clear();
-    if(n>0)
-        for(int k=0;k<n;k++)
-            enqueue(L10, TURN_MS);
-    else if(n<0)
-        for(int k=0;k<-n;k++)
-            enqueue(R10, TURN_MS);
-    enqueue(FWD, 3*FWD_MS);
+    if(dist_left > dist_right)
+        enqueue(L10, 5 * TURN_MS);
+    else
+        enqueue(R10, 5 * TURN_MS);
+    enqueue(FWD, 3 * FWD_MS);
 }

--- a/Test-Motor/Core/Src/globals.c
+++ b/Test-Motor/Core/Src/globals.c
@@ -1,4 +1,5 @@
 #include "config.h"
 
-volatile uint16_t us_dist[21] = {1000};
-volatile uint8_t us_idx = 0;
+volatile uint16_t dist_center = 1000;
+volatile uint16_t dist_left   = 1000;
+volatile uint16_t dist_right  = 1000;

--- a/Test-Motor/Core/Src/ultrasonic.c
+++ b/Test-Motor/Core/Src/ultrasonic.c
@@ -3,10 +3,12 @@
 #include "tim.h"
 #include "config.h"
 #include "beep.h"
+#include "queue.h"
 
 extern TIM_HandleTypeDef htim2;
 
 static volatile float last_distance = 0.0f;
+static volatile UltrasonicPos active_pos = US_POS_CENTER;
 
 static void delay_us(uint32_t us)
 {
@@ -34,8 +36,9 @@ float Ultrasonic_GetDistance(void)
     return last_distance;
 }
 
-void Ultrasonic_StartMeasurement(void)
+void Ultrasonic_StartMeasurement(UltrasonicPos pos)
 {
+    active_pos = pos;
     Ultrasonic_Trigger();
 }
 
@@ -55,11 +58,34 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
             HAL_TIM_Base_Stop(&htim2);
             uint32_t ticks = __HAL_TIM_GET_COUNTER(&htim2);
             last_distance = ticks * 100.0f / 58.0f; /* 100us tick */
-            us_dist[us_idx] = (uint16_t)last_distance;
-            if(us_dist[10] < D_SAFE)
-                Beep_On();
-            else
-                Beep_Off();
+
+            switch(active_pos)
+            {
+                case US_POS_CENTER:
+                    dist_center = (uint16_t)last_distance;
+                    if(dist_center < D_SAFE)
+                        Beep_On();
+                    else
+                        Beep_Off();
+                    break;
+                case US_POS_LEFT:
+                    dist_left = (uint16_t)last_distance;
+                    if(dist_left < D_SAFE)
+                    {
+                        queue_clear();
+                        enqueue(R10, 5 * TURN_MS);
+                    }
+                    break;
+                case US_POS_RIGHT:
+                    dist_right = (uint16_t)last_distance;
+                    if(dist_right < D_SAFE)
+                    {
+                        queue_clear();
+                        enqueue(L10, 5 * TURN_MS);
+                    }
+                    break;
+            }
+
             start = 0;
         }
     }


### PR DESCRIPTION
## Summary
- remove obsolete distance array and index tracking
- store latest left, right and centre distances
- trigger avoidance turns directly from ultrasonic callback
- simplify avoidance plan to choose turn direction based on side distance

## Testing
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_6878a77a99788333a0ad812f3e3e65a7