### PR TITLE
Restore ultrasonic array-based avoidance

### DIFF
--- a/F05_IR/STM32F103RCTX_FLASH.ld
+++ b/F05_IR/STM32F103RCTX_FLASH.ld
@@ -85,14 +85,14 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .ARM.extab (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .ARM.extab  : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
     . = ALIGN(4);
   } >FLASH
 
-  .ARM (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .ARM  : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     __exidx_start = .;
@@ -101,7 +101,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .preinit_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .preinit_array  : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
@@ -110,7 +110,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .init_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .init_array  : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
@@ -120,7 +120,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .fini_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .fini_array  : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);

--- a/Test-Motor/Core/Inc/config.h
+++ b/Test-Motor/Core/Inc/config.h
@@ -15,7 +15,7 @@
 
 typedef enum {FOLLOW, AVOID, RECOVER} State;
 
-extern volatile uint8_t g_L, g_R;
+extern volatile uint8_t g_L, g_R, g_avoid_ir;
 extern volatile uint16_t us_dist[21];
 extern volatile uint8_t  us_idx;
 extern volatile State g_state;

--- a/Test-Motor/Core/Inc/config.h
+++ b/Test-Motor/Core/Inc/config.h
@@ -16,11 +16,8 @@
 typedef enum {FOLLOW, AVOID, RECOVER} State;
 
 extern volatile uint8_t g_L, g_R;
-extern volatile uint16_t dist_center;
-extern volatile uint16_t dist_left;
-extern volatile uint16_t dist_right;
-
-typedef enum {US_POS_CENTER, US_POS_LEFT, US_POS_RIGHT} UltrasonicPos;
+extern volatile uint16_t us_dist[21];
+extern volatile uint8_t  us_idx;
 extern volatile State g_state;
 
 #endif /* __CONFIG_H */

--- a/Test-Motor/Core/Inc/gpio.h
+++ b/Test-Motor/Core/Inc/gpio.h
@@ -27,6 +27,9 @@ extern "C" {
 #define IR_LEFT_Pin   GPIO_PIN_0
 #define IR_LEFT_GPIO_Port GPIOB
 
+#define AVOID_Pin     GPIO_PIN_1
+#define AVOID_GPIO_Port GPIOB
+
 //void MX_GPIO_Init(void);
 
 #ifdef __cplusplus

--- a/Test-Motor/Core/Inc/ultrasonic.h
+++ b/Test-Motor/Core/Inc/ultrasonic.h
@@ -2,7 +2,6 @@
 #define __ULTRASONIC_H
 
 #include "stm32f1xx_hal.h"
-#include "config.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,7 +10,7 @@ extern "C" {
 void Ultrasonic_Init(void);
 void Ultrasonic_Trigger(void);
 float Ultrasonic_GetDistance(void);
-void Ultrasonic_StartMeasurement(UltrasonicPos pos);
+void Ultrasonic_StartMeasurement(void);
 
 #ifdef __cplusplus
 }

--- a/Test-Motor/Core/Src/avoid.c
+++ b/Test-Motor/Core/Src/avoid.c
@@ -4,7 +4,9 @@
 
 int front_blocked(void)
 {
-    return us_dist[10] < D_SAFE;
+    if (us_dist[8] < D_SAFE || us_dist[9] < D_SAFE || us_dist[10] < D_SAFE || us_dist[11] < D_SAFE || us_dist[12] < D_SAFE)
+        return 1;
+    return 0;
 }
 
 void avoid_plan(void)

--- a/Test-Motor/Core/Src/avoid.c
+++ b/Test-Motor/Core/Src/avoid.c
@@ -4,15 +4,46 @@
 
 int front_blocked(void)
 {
-    return dist_center < D_SAFE;
+    return us_dist[10] < D_SAFE;
 }
 
 void avoid_plan(void)
 {
+    uint8_t free[21];
+    for(int i=0;i<21;i++)
+        free[i] = (us_dist[i] > D_SAFE) ? 1 : 0;
+
+    if(g_L)
+        for(int i=0;i<5;i++)
+            free[i] = 0;
+    if(g_R)
+        for(int i=16;i<21;i++)
+            free[i] = 0;
+
+    int best_len = 0, best_start = 10;
+    int len = 0, start = 0;
+    for(int i=0;i<=21;i++)
+    {
+        if(i<21 && free[i])
+        {
+            if(len==0) start = i;
+            len++;
+        }
+        else
+        {
+            if(len>best_len){ best_len = len; best_start = start; }
+            len = 0;
+        }
+    }
+    int center = best_start + best_len/2;
+    int n = center - 10;
+
     queue_clear();
-    if(dist_left > dist_right)
-        enqueue(L10, 5 * TURN_MS);
-    else
-        enqueue(R10, 5 * TURN_MS);
-    enqueue(FWD, 3 * FWD_MS);
+    if(n>0)
+        for(int k=0;k<n;k++)
+            enqueue(L10, TURN_MS);
+    else if(n<0)
+        for(int k=0;k<-n;k++)
+            enqueue(R10, TURN_MS);
+    enqueue(FWD, 3*FWD_MS);
 }

--- a/Test-Motor/Core/Src/follow.c
+++ b/Test-Motor/Core/Src/follow.c
@@ -37,12 +37,12 @@ void follow_update(void)
             break;
         case +1:
             enqueue(BWD, 10*BWD_MS);
-            enqueue(R10, 15*TURN_MS);
+            enqueue(R10, 10*TURN_MS);
             enqueue(FWD, FWD_MS/2);
             break;
         case -1:
             enqueue(BWD, 10*BWD_MS);
-            enqueue(L10, 15*TURN_MS);
+            enqueue(L10, 10*TURN_MS);
             enqueue(FWD, FWD_MS/2);
             break;
         default:

--- a/Test-Motor/Core/Src/follow.c
+++ b/Test-Motor/Core/Src/follow.c
@@ -3,12 +3,13 @@
 #include "queue.h"
 #include "config.h"
 
-volatile uint8_t g_L = 0, g_R = 0;
+volatile uint8_t g_L = 0, g_R = 0, g_avoid_ir = 0;
 
 void ir_update(void)
 {
     g_L = (HAL_GPIO_ReadPin(IR_LEFT_GPIO_Port, IR_LEFT_Pin) == GPIO_PIN_SET);
     g_R = (HAL_GPIO_ReadPin(IR_RIGHT_GPIO_Port, IR_RIGHT_Pin) == GPIO_PIN_SET);
+    g_avoid_ir = (HAL_GPIO_ReadPin(AVOID_GPIO_Port, AVOID_Pin) == GPIO_PIN_RESET);
 }
 
 void follow_update(void)

--- a/Test-Motor/Core/Src/fsm.c
+++ b/Test-Motor/Core/Src/fsm.c
@@ -13,6 +13,14 @@ void fsm_tick(void)
 
     ir_update();
 
+    if(g_avoid_ir && queue_is_empty())
+    {
+        queue_clear();
+        enqueue(BWD, 12*BWD_MS);
+        enqueue(L10, 20*TURN_MS);
+        return;
+    }
+
     switch(g_state)
     {
         case FOLLOW:

--- a/Test-Motor/Core/Src/globals.c
+++ b/Test-Motor/Core/Src/globals.c
@@ -1,5 +1,4 @@
 #include "config.h"
 
-volatile uint16_t dist_center = 1000;
-volatile uint16_t dist_left   = 1000;
-volatile uint16_t dist_right  = 1000;
+volatile uint16_t us_dist[21] = {1000};
+volatile uint8_t  us_idx = 0;

--- a/Test-Motor/Core/Src/gpio.c
+++ b/Test-Motor/Core/Src/gpio.c
@@ -23,4 +23,10 @@ void MX_GPIO_Init(void)
 
     GPIO_InitStruct.Pin = BEEP_Pin;
     HAL_GPIO_Init(BEEP_GPIO_Port, &GPIO_InitStruct);
+
+    /* Configure IR avoid input */
+    GPIO_InitStruct.Pin = AVOID_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    HAL_GPIO_Init(AVOID_GPIO_Port, &GPIO_InitStruct);
 }

--- a/Test-Motor/Core/Src/main.c
+++ b/Test-Motor/Core/Src/main.c
@@ -401,6 +401,12 @@ static void MX_GPIO_Init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
+  /*Configure GPIO pin : PB1 (IR AVOID)*/
+  GPIO_InitStruct.Pin = GPIO_PIN_1;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
   /* EXTI interrupt init*/
   HAL_NVIC_SetPriority(EXTI1_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(EXTI1_IRQn);

--- a/Test-Motor/Core/Src/servo.c
+++ b/Test-Motor/Core/Src/servo.c
@@ -37,37 +37,25 @@ void Servo_SetAngle(float angle)
 
 }
 
-/*
- * Simplified sweeping logic: only measure at centre, left and right
- * extremes.  The servo cycles through the three positions and triggers
- * one ultrasonic measurement at each position.
- */
-static uint8_t sweep_state = 0; /* 0 -> centre, 1 -> left, 2 -> right */
+static int8_t sweep_idx = -10;
+static int8_t sweep_dir = 1;   /* 1 -> increasing, -1 -> decreasing */
 
 void Servo_SweepStep(void)
 {
-    switch (sweep_state)
+    sweep_idx += sweep_dir;
+    if(sweep_idx >= 10)
     {
-        case 0: /* centre */
-            Servo_SetAngle(SERVO_CENTER_ANGLE);
-
-            Ultrasonic_StartMeasurement(US_POS_CENTER);
-
-            sweep_state = 1;
-            break;
-        case 1: /* left */
-            Servo_SetAngle(SERVO_LEFT_BOUNDARY);
-
-            Ultrasonic_StartMeasurement(US_POS_LEFT);
-
-            sweep_state = 2;
-            break;
-        default: /* right */
-            Servo_SetAngle(SERVO_RIGHT_BOUNDARY);
-
-            Ultrasonic_StartMeasurement(US_POS_RIGHT);
-
-            sweep_state = 0;
-            break;
+        sweep_idx = 10;
+        sweep_dir = -1;
     }
+    else if(sweep_idx <= -10)
+    {
+        sweep_idx = -10;
+        sweep_dir = 1;
+    }
+
+    float angle = 100.0f + sweep_idx * 8.0f;
+    Servo_SetAngle(angle);
+    us_idx = sweep_idx + 10;
+    Ultrasonic_StartMeasurement();
 }


### PR DESCRIPTION
## Summary
- revert simplified ultrasonic logic
- restore distance array and scanning
- clean up global variables

## Testing
- `cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_6878b14b005c8333a5ab6a1fb56d7069