### PR TITLE
Add IR obstacle handling for Test-Motor

### DIFF
--- a/Test-Motor/Core/Inc/config.h
+++ b/Test-Motor/Core/Inc/config.h
@@ -15,7 +15,7 @@
 
 typedef enum {FOLLOW, AVOID, RECOVER} State;
 
-extern volatile uint8_t g_L, g_R;
+extern volatile uint8_t g_L, g_R, g_avoid_ir;
 extern volatile uint16_t us_dist[21];
 extern volatile uint8_t  us_idx;
 extern volatile State g_state;

--- a/Test-Motor/Core/Inc/gpio.h
+++ b/Test-Motor/Core/Inc/gpio.h
@@ -27,6 +27,9 @@ extern "C" {
 #define IR_LEFT_Pin   GPIO_PIN_0
 #define IR_LEFT_GPIO_Port GPIOB
 
+#define AVOID_Pin     GPIO_PIN_1
+#define AVOID_GPIO_Port GPIOB
+
 //void MX_GPIO_Init(void);
 
 #ifdef __cplusplus

--- a/Test-Motor/Core/Src/follow.c
+++ b/Test-Motor/Core/Src/follow.c
@@ -3,12 +3,13 @@
 #include "queue.h"
 #include "config.h"
 
-volatile uint8_t g_L = 0, g_R = 0;
+volatile uint8_t g_L = 0, g_R = 0, g_avoid_ir = 0;
 
 void ir_update(void)
 {
     g_L = (HAL_GPIO_ReadPin(IR_LEFT_GPIO_Port, IR_LEFT_Pin) == GPIO_PIN_SET);
     g_R = (HAL_GPIO_ReadPin(IR_RIGHT_GPIO_Port, IR_RIGHT_Pin) == GPIO_PIN_SET);
+    g_avoid_ir = (HAL_GPIO_ReadPin(AVOID_GPIO_Port, AVOID_Pin) == GPIO_PIN_RESET);
 }
 
 void follow_update(void)

--- a/Test-Motor/Core/Src/fsm.c
+++ b/Test-Motor/Core/Src/fsm.c
@@ -13,6 +13,14 @@ void fsm_tick(void)
 
     ir_update();
 
+    if(g_avoid_ir && queue_is_empty())
+    {
+        queue_clear();
+        enqueue(BWD, 12*BWD_MS);
+        enqueue(L10, 20*TURN_MS);
+        return;
+    }
+
     switch(g_state)
     {
         case FOLLOW:

--- a/Test-Motor/Core/Src/gpio.c
+++ b/Test-Motor/Core/Src/gpio.c
@@ -23,4 +23,10 @@ void MX_GPIO_Init(void)
 
     GPIO_InitStruct.Pin = BEEP_Pin;
     HAL_GPIO_Init(BEEP_GPIO_Port, &GPIO_InitStruct);
+
+    /* Configure IR avoid input */
+    GPIO_InitStruct.Pin = AVOID_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    HAL_GPIO_Init(AVOID_GPIO_Port, &GPIO_InitStruct);
 }

--- a/Test-Motor/Core/Src/main.c
+++ b/Test-Motor/Core/Src/main.c
@@ -401,6 +401,12 @@ static void MX_GPIO_Init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
+  /*Configure GPIO pin : PB1 (IR AVOID)*/
+  GPIO_InitStruct.Pin = GPIO_PIN_1;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
   /* EXTI interrupt init*/
   HAL_NVIC_SetPriority(EXTI1_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(EXTI1_IRQn);


### PR DESCRIPTION
## Summary
- integrate IR obstacle input (PB1) and handle it in the finite state machine
- expose new `g_avoid_ir` variable and update sensor read function
- configure new IR input pin in `MX_GPIO_Init`

## Testing
- `cmake -S Test-Motor -B Test-Motor/build`
- `cmake --build Test-Motor/build`

------
https://chatgpt.com/codex/tasks/task_e_6878b6830b388333b453f4385297fdfb